### PR TITLE
Autoversion with gcr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.pyc
 .env*
 .vscode
+.venv

--- a/servicer/builtin/service_adapters/package/base_package.py
+++ b/servicer/builtin/service_adapters/package/base_package.py
@@ -119,7 +119,12 @@ class Service(BaseService):
     def if_package_version_exists(self, **package_info):
         self.logger.log('checking for %s-%s...' % (package_info['name'], package_info['version']))
 
-        version_list = self.get_existing_versions(**package_info)
+        version_list_method_name = "get_existing_versions"
+        if 'existing_versions_source' in self.config:
+            version_list_method_name = "get_existing_%s_versions" % self.config['existing_versions_source']
+
+        version_list_method = getattr(self, version_list_method_name)
+        version_list = version_list_method(**package_info)
 
         self.logger.log('existing versions: %s' % version_list)
 
@@ -129,17 +134,6 @@ class Service(BaseService):
                 raise ValueError('Package already exists! %s-%s' % (package_info['name'], package_info['version']))
 
         return package_info['version_exists']
-
-    def get_existing_versions(self, **package_info):
-        if 'existing_versions_source' not in package_info:
-            raise NameError('Service must provide existing_versions_source.')
-        self.logger.log('existing_versions_source is: %s' % package_info['existing_versions_source'])
-
-        versions_list_method_name = "get_existing_%s_versions" % package_info['existing_versions_source']
-        versions_list_method = getattr(self, versions_list_method_name)
-        version_list = versions_list_method(**package_info)
-
-        return version_list
 
     def get_existing_gcr_versions(self, **package_info):
         docker_image = package_info['docker_image_path']

--- a/servicer/builtin/service_adapters/package/base_package.py
+++ b/servicer/builtin/service_adapters/package/base_package.py
@@ -32,7 +32,7 @@ class Service(BaseService):
     def run_steps(self, steps):
         for step in steps:
             getattr(self, step['type'])(**step.get('args', {}))
-    
+
     def set_auto_version(self, max_increment=10, auto_detect_version=True):
         self.logger.log('auto-versioning (auto_detect_version=%s)...' % auto_detect_version)
 
@@ -46,7 +46,7 @@ class Service(BaseService):
             while True:
                 any_invalid_version = False
                 for pi in self.package_info:
-                    
+
                     pi['version_exists'] = self.if_package_version_exists(**pi)
                     if pi['version_exists']:
                         any_invalid_version = True
@@ -167,7 +167,6 @@ class Service(BaseService):
 
         if 'version' not in self.package_info:
             if 'version_regex' in self.package_info:
-                print('version_regex in text is: %s' % self.package_info['version_regex'])
                 self.version_regex = re.compile(self.package_info['version_regex'])
             self.package_info['version'] = self.package_version(self.config['package_info']['version_file_path'])
             print('package version is %s' % self.package_info['version'])

--- a/servicer/builtin/service_adapters/package/base_package.py
+++ b/servicer/builtin/service_adapters/package/base_package.py
@@ -132,7 +132,7 @@ class Service(BaseService):
     def get_existing_versions(self, **package_info):
         if 'existing_versions_source' not in package_info:
             raise NameError('Service must provide existing_versions_source.')
-        print('existing_versions_source is: %s' % package_info['existing_versions_source'])
+        self.logger.log('existing_versions_source is: %s' % package_info['existing_versions_source'])
 
         versions_list_method_name = "get_existing_%s_versions" % package_info['existing_versions_source']
         versions_list_method = getattr(self, versions_list_method_name)
@@ -169,7 +169,7 @@ class Service(BaseService):
             if 'version_regex' in self.package_info:
                 self.version_regex = re.compile(self.package_info['version_regex'])
             self.package_info['version'] = self.package_version(self.config['package_info']['version_file_path'])
-            print('package version is %s' % self.package_info['version'])
+            self.logger.log('package version is %s' % self.package_info['version'])
 
         self.results['package_name'] = self.package_info['name']
         if isinstance(self.results['package_name'], list):

--- a/servicer/builtin/service_adapters/package/base_package.py
+++ b/servicer/builtin/service_adapters/package/base_package.py
@@ -9,6 +9,7 @@ from servicer.git import Git
 class Service(BaseService):
     def __init__(self, config=None, logger=None):
         super().__init__(config=config, logger=logger)
+        self.package_version_format = None
 
         if 'git' in config:
             self.git = config['git']['module']
@@ -157,13 +158,11 @@ class Service(BaseService):
         if 'name' not in self.package_info:
             self.package_info['name'] = self.package_name(self.config['package_info']['package_file_path'])
 
-        try:
-            self.package_version_format
-        except AttributeError:
-            if 'package_version_format' in self.package_info:
-                self.package_version_format = self.package_info['package_version_format']
-            else:
-                raise NameError('Service must provide package_version_format.')
+        if 'package_version_format' in self.package_info:
+            self.package_version_format = self.package_info['package_version_format']
+
+        if not self.package_version_format:
+            raise ValueError('Service must provide package_version_format.')
 
         if 'version' not in self.package_info:
             if 'version_regex' in self.package_info:

--- a/servicer/builtin/service_adapters/package/base_package.py
+++ b/servicer/builtin/service_adapters/package/base_package.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import json
+import re
 
 from ..service import Service as BaseService
 from servicer.git import Git
@@ -31,6 +32,16 @@ class Service(BaseService):
     def run_steps(self, steps):
         for step in steps:
             getattr(self, step['type'])(**step.get('args', {}))
+    
+    def print_dict(dictionary, ident = '', braces=1):
+        """ Recursively prints nested dictionaries."""
+
+        for key, value in dictionary.iteritems():
+            if isinstance(value, dict):
+                print('%s%s%s%s' %(ident, braces*'[', key, braces*']'))
+                print_dict(value, ident+'  ', braces+1)
+            else:
+                print(ident + '%s = %s' %(key, value))
 
     def set_auto_version(self, max_increment=10, auto_detect_version=True):
         self.logger.log('auto-versioning (auto_detect_version=%s)...' % auto_detect_version)
@@ -40,11 +51,16 @@ class Service(BaseService):
             self.package_info = [self.package_info]
 
         if auto_detect_version:
+            print('auto_detect_version is true')
             current_increment = 0
             version_changed = False
             while True:
+                print('looping...')
                 any_invalid_version = False
+                # Loop through the package_info of every (package-based?) service
                 for pi in self.package_info:
+                    print('service name: %s' % pi['name'])
+                    
                     pi['version_exists'] = self.if_package_version_exists(**pi)
                     if pi['version_exists']:
                         any_invalid_version = True
@@ -116,11 +132,7 @@ class Service(BaseService):
     def if_package_version_exists(self, **package_info):
         self.logger.log('checking for %s-%s...' % (package_info['name'], package_info['version']))
 
-        version_list = None
-        if 'version_source' in self.config and self.config['version_source'] == 'gcr':
-            version_list = self.get_existing_gcr_versions(**package_info)
-        else:
-            version_list = self.get_existing_versions(**package_info)
+        version_list = self.get_existing_versions(**package_info)
 
         self.logger.log('existing versions: %s' % version_list)
 
@@ -131,10 +143,23 @@ class Service(BaseService):
 
         return package_info['version_exists']
 
+    def get_existing_versions(self, **package_info):
+        if 'version_source' in self.config:
+            raise NameError('Service must provide version_source.')
+
+        version_list_method_name = "get_existing_%s_versions" % package_info['version_source']
+        print('version_list_method_name is: %s' % version_list_method_name)
+        version_list_method = getattr(self, version_list_method_name)
+        version_list = version_list_method(**package_info)
+
+        return version_list
+
     def get_existing_gcr_versions(self, **package_info):
+        print('getting existing gcr versions...')
         docker_image = package_info['docker_image_path']
-        if 'name' in package_info:
-            docker_image = '%s/%s' % (docker_image, package_info['name'])
+        # BREAKING CHANGE
+        #if 'name' in package_info:
+        #    docker_image = '%s/%s' % (docker_image, package_info['name'])
 
         result = self.run('gcloud container images list-tags %s --format=json' % docker_image, hide_output=True)
 
@@ -149,8 +174,21 @@ class Service(BaseService):
 
         if 'name' not in self.package_info:
             self.package_info['name'] = self.package_name(self.config['package_info']['package_file_path'])
+
+        try:
+            self.package_version_format
+        except AttributeError:
+            if 'package_version_format' in self.package_info:
+                self.package_version_format = self.package_info['package_version_format']
+            else:
+                raise NameError('Service must provide package_version_format.')
+
         if 'version' not in self.package_info:
+            if 'version_regex' in self.package_info:
+                print('version_regex in text is: %s' % self.package_info['version_regex'])
+                self.version_regex = re.compile(self.package_info['version_regex'])
             self.package_info['version'] = self.package_version(self.config['package_info']['version_file_path'])
+            print('package version is %s' % self.package_info['version'])
 
         self.results['package_name'] = self.package_info['name']
         if isinstance(self.results['package_name'], list):
@@ -175,7 +213,7 @@ class Service(BaseService):
                 name = result.groups()[0]
                 return name
             else:
-                raise ValueError('Package version not defined at: %s' % path)
+                raise ValueError('Package name not defined at: %s' % path)
 
     def package_version(self, path):
         with open(path) as f:

--- a/servicer/builtin/service_adapters/package/sbt.py
+++ b/servicer/builtin/service_adapters/package/sbt.py
@@ -67,10 +67,6 @@ class Service(BasePackageService):
             if os.path.exists(package_version_path):
                 for sv in scala_versions:
                     pi = self.config['package_info'].copy()
-                    # TODO Each version.sbt is associated with on service.
-                    # It needs to be possible to define the name of the service (pi['name'])
-                    # explicitly in the definition of the service, or the autoversioning will
-                    # fail.
                     pi['name'] = self.package_name(package_file_path)
                     pi['scala_version'] = sv
                     pi['version'] = self.package_version(package_version_path)

--- a/servicer/builtin/service_adapters/package/sbt.py
+++ b/servicer/builtin/service_adapters/package/sbt.py
@@ -67,6 +67,10 @@ class Service(BasePackageService):
             if os.path.exists(package_version_path):
                 for sv in scala_versions:
                     pi = self.config['package_info'].copy()
+                    # TODO Each version.sbt is associated with on service.
+                    # It needs to be possible to define the name of the service (pi['name'])
+                    # explicitly in the definition of the service, or the autoversioning will
+                    # fail.
                     pi['name'] = self.package_name(package_file_path)
                     pi['scala_version'] = sv
                     pi['version'] = self.package_version(package_version_path)

--- a/servicer/servicer.py
+++ b/servicer/servicer.py
@@ -563,7 +563,7 @@ class Servicer():
                     self.logger.log('found matching executable: %s' % mp['file_path'])
                     return mp['file_path']
 
-        self.logger.log('no module found!')
+        self.logger.log('no modules found!')
         sys.exit(1)
 
     def load_steps(self):

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     packages = find_packages(),
     python_requires = '>=3.5',
     url = 'https://github.com/wmgroot/servicer',
-    version = '0.9.14',
+    version = '0.9.15',
 )

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     packages = find_packages(),
     python_requires = '>=3.5',
     url = 'https://github.com/wmgroot/servicer',
-    version = '0.9.15',
+    version = '0.10.0',
 )


### PR DESCRIPTION
This allows any base_package service to optionally use GCR as a version source, and facilitates the addition of further language-agnostic versioning sources.