### PR TITLE
Facilitate GCR subdirectories.

### DIFF
--- a/servicer/builtin/service_adapters/package/base_package.py
+++ b/servicer/builtin/service_adapters/package/base_package.py
@@ -137,6 +137,8 @@ class Service(BaseService):
 
     def get_existing_gcr_versions(self, **package_info):
         docker_image = package_info['docker_image_path']
+        if 'gcr_package_subdir' in package_info and package_info['gcr_package_subdir']:
+            docker_image = '%s/%s' % (docker_image, package_info['name'])
 
         result = self.run('gcloud container images list-tags %s --format=json' % docker_image, hide_output=True)
 

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     packages = find_packages(),
     python_requires = '>=3.5',
     url = 'https://github.com/wmgroot/servicer',
-    version = '0.10.0',
+    version = '0.10.1',
 )


### PR DESCRIPTION
This optionally looks for versions in package-specific GCR subdirectories. This is particularly valuable for nested Scala projects.