### PR TITLE
[interpolator] addresses an issue where tokens were falling back to their default values before having a chance to use values defined at run-time

### DIFF
--- a/servicer/builtin/service_adapters/service.py
+++ b/servicer/builtin/service_adapters/service.py
@@ -1,7 +1,6 @@
 import os
 
 from servicer.run import run
-from servicer.token_interpolator import TokenInterpolator
 
 class Service:
     def __init__(self, config=None, logger=None):
@@ -15,9 +14,6 @@ class Service:
 
         self.project = os.environ['PROJECT_NAME']
         self.environment = os.getenv('SERVICE_ENVIRONMENT')
-
-        self.token_interpolator = TokenInterpolator()
-        self.token_interpolator.interpolate_tokens(self.config, os.environ)
 
     def up(self):
         pass

--- a/servicer/config_loader.py
+++ b/servicer/config_loader.py
@@ -107,7 +107,7 @@ class ConfigLoader():
 
     def interpolate_config(self, config):
         self.logger.log('Interpolating Tokens...')
-        self.token_interpolator.interpolate_tokens(config, os.environ, ignore_missing_key=True)
+        self.token_interpolator.interpolate_tokens(config, os.environ, ignore_missing_key=True, ignore_default=True)
 
     def load_environment_variables(self, variables={}):
         for key, value in variables.items():

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     },
     include_package_data = True,
     install_requires = [
-        'PyYAML==3.13',
+        'PyYAML==4.2b4',
         'requests==2.20.1',
     ],
     keywords = 'ci cd automation environment service',
@@ -30,5 +30,5 @@ setup(
     packages = find_packages(),
     python_requires = '>=3.5',
     url = 'https://github.com/wmgroot/servicer',
-    version = '0.10.1',
+    version = '0.10.2',
 )


### PR DESCRIPTION
Should address issues with using defaults combined with values that become defined during build execution (such as by setting an env_var during build execution).

Also updates pyyaml dependency to address a security concern.