### PR TITLE
no_verify when git tagging.

### DIFF
--- a/servicer/git.py
+++ b/servicer/git.py
@@ -50,7 +50,7 @@ class Git():
         self.run(command, hide_output=hide_output or self.hide_output)
 
         if push:
-            self.push(ref=tag)
+            self.push(ref=tag, no_verify=True)
 
     def delete_tag(self, tags):
         if not isinstance(tags, list):
@@ -58,7 +58,7 @@ class Git():
 
         for tag in tags:
             self.run('git tag -d %s' % tag, check=False)
-            self.push(ref=':refs/tags/%s' % tag)
+            self.push(ref=':refs/tags/%s' % tag, no_verify=True)
 
     def list_tags(self):
         result = self.run('git tag', hide_output=True)


### PR DESCRIPTION
When the repository is using git lfs, git tagging inconsistently fails. This change has tagging commits avoid the git-lfs hook.